### PR TITLE
fix: remediate Checkmarx SAST findings

### DIFF
--- a/models/dash_cam_net/dashcamnet.py
+++ b/models/dash_cam_net/dashcamnet.py
@@ -11,8 +11,9 @@ class DashCamNet(NvidiaBase):
 
     def get_cmd(self):
         return [
-            f'detectnet_v2 inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")} '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}']
+            'detectnet_v2', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', self.model_key
+        ]

--- a/models/face_detect/facenet.py
+++ b/models/face_detect/facenet.py
@@ -21,11 +21,10 @@ class FaceNet:
         cli_filepath = os.path.join('/tmp', 'ngccli', 'ngc-cli', 'ngc')
         dest_path = os.path.join('/tmp', 'tao_models')
         download_status = subprocess.Popen(
-            [f'{cli_filepath} registry model download-version "{self.model_version}" --dest {dest_path}'],
+            [cli_filepath, 'registry', 'model', 'download-version', self.model_version, '--dest', dest_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         download_status.wait()
         if download_status.returncode != 0:
@@ -44,15 +43,14 @@ class FaceNet:
 
         specs_filepath = os.path.join(self.current_dir, "inference_spec.txt")
         os.makedirs(self.res_dir, exist_ok=True)
-        predict_status = subprocess.Popen([
-            f'detectnet_v2 inference '
-            f'-e {specs_filepath} '
-            f'-i {images_dir} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}'],
+        predict_status = subprocess.Popen(
+            ['detectnet_v2', 'inference',
+             '-e', specs_filepath,
+             '-i', images_dir,
+             '-r', self.res_dir,
+             '-k', self.model_key],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         predict_status.wait()
         if predict_status.returncode != 0:

--- a/models/face_detect_ir/facedetectir.py
+++ b/models/face_detect_ir/facedetectir.py
@@ -10,8 +10,9 @@ logger = logging.getLogger('[FaceDetectIR]')
 class FaceDetectIR(NvidiaBase):
     def get_cmd(self):
         return [
-            f'detectnet_v2 inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")} '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}']
+            'detectnet_v2', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', self.model_key
+        ]

--- a/models/license_plate_detection/license_plate_detection.py
+++ b/models/license_plate_detection/license_plate_detection.py
@@ -11,10 +11,10 @@ class LPDNet(NvidiaBase):
     def get_cmd(self):
         tlt_filepath = os.path.join('/tmp', 'tao_models', 'lpdnet_vunpruned_v2.1', 'yolov4_tiny_usa_trainable.tlt')
         return [
-            f'yolo_v4_tiny inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "yolo_v4_tiny_retrain_kitti.txt")} '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key} '
-            f'-m {tlt_filepath}'
+            'yolo_v4_tiny', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "yolo_v4_tiny_retrain_kitti.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', self.model_key,
+            '-m', tlt_filepath
         ]

--- a/models/license_plate_recognition/license_plate_recognition.py
+++ b/models/license_plate_recognition/license_plate_recognition.py
@@ -13,13 +13,13 @@ class LPRNet(NvidiaBase):
     def get_cmd(self):
         tlt_filepath = os.path.join('/tmp', 'tao_models', 'lprnet_vtrainable_v1.0', 'us_lprnet_baseline18_trainable.tlt')
         return [
-            f'lprnet inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "lprnet_spec.txt")}  '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k nvidia_tlt '
-            f'-m {tlt_filepath}'
-            ]
+            'lprnet', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "lprnet_spec.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', 'nvidia_tlt',
+            '-m', tlt_filepath
+        ]
 
     def parse_results(self, predict_status):
         # Read outputs

--- a/models/model_adapter.py
+++ b/models/model_adapter.py
@@ -46,22 +46,21 @@ class NvidiaBase(dl.BaseModelAdapter):
         os.makedirs(name='/tmp/ngccli', exist_ok=True)
         logger.info('downloading "https://ngc.nvidia.com/downloads/ngccli_cat_linux.zip"')
         wget_command = subprocess.Popen(
-            ['wget "https://ngc.nvidia.com/downloads/ngccli_cat_linux.zip" -O /tmp/ngccli/ngccli_cat_linux.zip'],
+            ['wget', 'https://ngc.nvidia.com/downloads/ngccli_cat_linux.zip',
+             '-O', '/tmp/ngccli/ngccli_cat_linux.zip'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         wget_command.wait()
         if wget_command.returncode != 0:
             raise ValueError('Failed downloading ngccli_cat_linux.zip')
         logger.info('unzipping "ngccli_cat_linux.zip" updated files')
         unzip_command = subprocess.Popen(
-            ['unzip -u /tmp/ngccli/ngccli_cat_linux.zip -d /tmp/ngccli/'],
+            ['unzip', '-u', '/tmp/ngccli/ngccli_cat_linux.zip', '-d', '/tmp/ngccli/'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         unzip_command.wait()
         if unzip_command.returncode != 0:
@@ -78,11 +77,10 @@ class NvidiaBase(dl.BaseModelAdapter):
         self._prepare_ngc_cli()
         logger.info('login to ngc')
         process = subprocess.Popen(
-            ['/tmp/ngccli/ngc-cli/ngc config set'],
+            ['/tmp/ngccli/ngc-cli/ngc', 'config', 'set'],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         input_data = (
             self.ngc_config["ngc_api_key"].encode() + b'\n\n' +
@@ -104,13 +102,12 @@ class NvidiaBase(dl.BaseModelAdapter):
 
         cli_filepath = os.path.join('/tmp', 'ngccli', 'ngc-cli', 'ngc')
         dest_path = os.path.join('/tmp', 'tao_models')
-        cmd = [f'{cli_filepath} registry model download-version "{self.model_version}" --dest {dest_path}']
+        cmd = [cli_filepath, 'registry', 'model', 'download-version', self.model_version, '--dest', dest_path]
         download_status = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         download_status.wait()
         if download_status.returncode != 0:
@@ -136,8 +133,7 @@ class NvidiaBase(dl.BaseModelAdapter):
             predict_status = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                shell=True
+                stderr=subprocess.PIPE
             )
             predict_status.wait()
             if predict_status.returncode != 0:

--- a/models/people_net/peoplenet.py
+++ b/models/people_net/peoplenet.py
@@ -10,8 +10,9 @@ class PeopleNet(NvidiaBase):
 
     def get_cmd(self):
         return [
-            f'detectnet_v2 inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")} '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}']
+            'detectnet_v2', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', self.model_key
+        ]

--- a/models/point_pillar_net/pointpillarnet.py
+++ b/models/point_pillar_net/pointpillarnet.py
@@ -24,11 +24,10 @@ class PointPillarNet:
         cli_filepath = os.path.join('/tmp', 'ngccli', 'ngc-cli', 'ngc')
         dest_path = os.path.join('/tmp', 'tao_models')
         download_status = subprocess.Popen(
-            [f'{cli_filepath} registry model download-version "{self.model_version}" --dest {dest_path}'],
+            [cli_filepath, 'registry', 'model', 'download-version', self.model_version, '--dest', dest_path],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         download_status.wait()
         if download_status.returncode != 0:
@@ -60,14 +59,13 @@ class PointPillarNet:
 
         specs_filepath = os.path.join(self.current_dir, "inference_spec.yaml")
         os.makedirs(self.res_dir, exist_ok=True)
-        predict_status = subprocess.Popen([
-            f'pointpillars inference '
-            f'-e {specs_filepath} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}'],
+        predict_status = subprocess.Popen(
+            ['pointpillars', 'inference',
+             '-e', specs_filepath,
+             '-r', self.res_dir,
+             '-k', self.model_key],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            shell=True
+            stderr=subprocess.PIPE
         )
         predict_status.wait()
         if predict_status.returncode != 0:

--- a/models/traffic_cam_net/trafficcamnet.py
+++ b/models/traffic_cam_net/trafficcamnet.py
@@ -9,8 +9,9 @@ logger = logging.getLogger('[TrafficCamNet]')
 class TrafficCamNet(NvidiaBase):
     def get_cmd(self):
         return [
-            f'detectnet_v2 inference '
-            f'-e {os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")} '
-            f'-i {self.images_path} '
-            f'-r {self.res_dir} '
-            f'-k {self.model_key}']
+            'detectnet_v2', 'inference',
+            '-e', str(os.path.join(Path(__file__).parent.absolute(), "inference_spec.txt")),
+            '-i', self.images_path,
+            '-r', self.res_dir,
+            '-k', self.model_key
+        ]


### PR DESCRIPTION
## Summary

Automated remediation of **1 Critical (13 instances)** Checkmarx CxSAST findings.

### Fixes Applied
- Removed shell=True from all subprocess.Popen calls across 9 model adapter files (CWE-78)
- Converted shell command strings to proper argument lists, eliminating shell interpretation

### Why
Checkmarx SAST scan identified security vulnerabilities in this repository. These changes harden the codebase by addressing the flagged issues while preserving functionality.

### Base Image Note
Any findings related to the Docker base image (OS packages, Python runtime) are outside the scope of this PR and should be addressed via base image updates.